### PR TITLE
Fix index column in draft data loading

### DIFF
--- a/draft_app_streamlit.py
+++ b/draft_app_streamlit.py
@@ -8,7 +8,8 @@ if 'need_rerun' not in st.session_state:
 # Load projections data if not already in session state
 if 'projections_data' not in st.session_state:
     file_path = "2023_season_projections.csv"
-    st.session_state.projections_data = pd.read_csv(file_path)
+    # Drop the first unnamed index column if present
+    st.session_state.projections_data = pd.read_csv(file_path, index_col=0)
 
 # Initialize search query if not already in session state
 if 'search_query' not in st.session_state:


### PR DESCRIPTION
## Summary
- drop unnamed index column when loading CSV

## Testing
- `python -m py_compile draft_app_streamlit.py`

------
https://chatgpt.com/codex/tasks/task_e_683f63c8b9f4832f8e96676768e9c654